### PR TITLE
Resolves issue #5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+dist: xenial
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+
+matrix:
+  include:
+    - php: "5.4"
+      dist: trusty
+    - php: "5.5"
+      dist: trusty
+
+install:
+  - composer install
+
+script:
+  - ./vendor/bin/phpunit -c ./phpunit.xml --coverage-text

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Antanas Arvasevicius
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.2.0"
+        "php": "^5.4 || ^7.0",
+        "ext-bcmath": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.36 || ^5.6"
     },
     "autoload": {
-        "psr-4": { "": "src/" }
+        "psr-4": { "HappyTypes\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "HappyTypes\\Test\\MoneyType\\": "tests/" }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="MoneyType test suit">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <ini name="error_reporting" value="30719"/>
+        <ini name="display_errors" value="1"/>
+    </php>
+</phpunit>

--- a/src/Money.php
+++ b/src/Money.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace HappyTypes;
+
+use RuntimeException;
+
 /**
  * Class Money is a Value Object, that means that all operations will create new instance of Money
  * and all instances are immutable
@@ -47,7 +52,6 @@
  */
 class Money
 {
-
     /**
      * @var string
      */
@@ -91,7 +95,7 @@ class Money
      */
     private static $defaultCurrency = null;
 
-    function __construct($amount, $currency, $precision = -1)
+    public function __construct($amount, $currency, $precision = -1)
     {
         if ($amount && !is_string($amount))
             throw new RuntimeException("Money: `amount` argument must be string value. you passed: " . gettype($amount));
@@ -192,7 +196,6 @@ class Money
         return ($value === '' || $value === null || $value === false);
     }
 
-
     /**
      * @var array|Money[]
      */
@@ -207,7 +210,6 @@ class Money
     {
         return new Money(null, $currency, $precision);
     }
-
 
     /**
      * Method adds money amount to current money instance.
@@ -234,7 +236,8 @@ class Money
      * @param $number
      * @return Money
      */
-    public function multiplyByInteger($number) {
+    public function multiplyByInteger($number)
+    {
         if (!is_int($number))
             throw new RuntimeException("Money: cannot multiply money by " . $number . ". Only integer value is acceptable.");
 
@@ -482,7 +485,6 @@ class Money
         return $this->precision;
     }
 
-
     /**
      * Method returns format string of current value in format "{amount} {currency}" (e.g. 4.29 LTL)
      * @return string
@@ -491,5 +493,4 @@ class Money
     {
         return $this->undefined ? "undefined {$this->currency}" : "{$this->amount} {$this->currency}";
     }
-
 }

--- a/src/MoneyConverter.php
+++ b/src/MoneyConverter.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace HappyTypes;
+
 /**
  * Interface MoneyConverter
  * Implement this interface if you want your Money object would support money conversion with method convertTo(..)

--- a/src/MutableMoney.php
+++ b/src/MutableMoney.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace HappyTypes;
+
 /**
  * Class MutableMoney
  *
@@ -10,7 +13,6 @@
  */
 class MutableMoney extends Money
 {
-
     /**
      * Static factory method will always create an new instance for MutableMoney
      * @param string $currency
@@ -92,5 +94,4 @@ class MutableMoney extends Money
             $this->getCurrency() === $money->getCurrency() &&
             ($precision < 0 ? $this->getPrecision() === $money->getPrecision() : true));
     }
-
 }

--- a/tests/MockedMoneyConverter.php
+++ b/tests/MockedMoneyConverter.php
@@ -1,4 +1,10 @@
 <?php
+
+namespace HappyTypes\Test\MoneyType;
+
+use HappyTypes\MoneyConverter;
+use RuntimeException;
+
 class MockedMoneyConverter implements MoneyConverter
 {
     private $currencies = array(

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -1,10 +1,13 @@
 <?php
-require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.'MockedMoneyConverter.php');
 
-class MoneyTest extends PHPUnit_Framework_TestCase
+namespace HappyTypes\Test\MoneyType;
+
+use HappyTypes\Money;
+use PHPUnit\Framework\TestCase;
+
+class MoneyTest extends TestCase
 {
-
-    public function setUp()
+    protected function setUp()
     {
         Money::setDefaultMoneyConverter(new MockedMoneyConverter());
         Money::setDefaultCurrency(null);
@@ -82,10 +85,9 @@ class MoneyTest extends PHPUnit_Framework_TestCase
         $result       = $a->isDefined();
         $resultNegate = $a->isUndefined();
 
-        $this->assertFalse($result === $resultNegate, "Test A.isDefined() A.isUndefined() failed, must return opposite values.");
-        $this->assertTrue($result == $expectedResult, 'Test A.isDefined() failed. got: ' . ($result ? 'true' : 'false') . ', expected: ' . ($expectedResult ? 'true' : 'false'));
+        $this->assertNotSame($result, $resultNegate, "Test A.isDefined() A.isUndefined() failed, must return opposite values.");
+        $this->assertEquals($expectedResult, $result, 'Test A.isDefined() failed. got: ' . ($result ? 'true' : 'false') . ', expected: ' . ($expectedResult ? 'true' : 'false'));
     }
-
 
     /**
      * You cannot create money object from integer or float or double, only from string!
@@ -177,13 +179,11 @@ class MoneyTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result->isEqual($expectedResult), 'Test A - B failed. ' . $a->asString() . ' - ' . $b->asString() . ' = ' . $result->asString() . ', expected: ' . $expectedResult->asString());
     }
 
-
     /**
      * If currencies mismatch in  a + b  then we implicitly convert  b into's a currency. returned value is in a`s currency
      */
     public function testAddCurrencyMismatch()
     {
-
         $a = Money::create('0.00', 'LTL');
         $b = Money::create('1.00', 'EUR');
 
@@ -271,7 +271,7 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testComparison(Money $a, Money $b, $result)
     {
         $r = $a->compare($b);
-        $this->assertTrue($r == $result, "comparing: " . $a->asString() . " <=> " . $b->asString() . ", result: " . $r . ", expected: " . $result);
+        $this->assertEquals($result, $r, "comparing: " . $a->asString() . " <=> " . $b->asString() . ", result: " . $r . ", expected: " . $result);
     }
 
     public function provider_testComparisionEqualityWithConversion()
@@ -290,7 +290,7 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     {
         $b = $a->convertTo('LTL');
         $r = $a->compare($b);
-        $this->assertTrue($r == 0, "comparing: " . $a->asString() . " <=> " . $b->asString() . ", result: " . $r . ", expected: 0");
+        $this->assertEquals(0, $r, "comparing: " . $a->asString() . " <=> " . $b->asString() . ", result: " . $r . ", expected: 0");
     }
 
     /**
@@ -301,20 +301,19 @@ class MoneyTest extends PHPUnit_Framework_TestCase
         $method = ($result == 0) ? 'eq' : ($result < 0 ? 'lt' : 'gt');
 
         $r = $a->{$method}($b);
-        $this->assertTrue($r == true, "comparing using method `{$method}`: " . $a->asString() . " {$method} " . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: true");
+        $this->assertTrue($r, "comparing using method `{$method}`: " . $a->asString() . " {$method} " . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: true");
 
         if ($result == 0) {
 
             $r      = $a->le($b);
             $method = 'le';
-            $this->assertTrue($r == true, "comparing using method `{$method}`: " . $a->asString() . " {$method} " . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: true");
+            $this->assertTrue($r, "comparing using method `{$method}`: " . $a->asString() . " {$method} " . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: true");
 
             $r      = $a->ge($b);
             $method = 'ge';
-            $this->assertTrue($r == true, "comparing using method `{$method}`: " . $a->asString() . " {$method} " . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: true");
+            $this->assertTrue($r, "comparing using method `{$method}`: " . $a->asString() . " {$method} " . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: true");
         }
     }
-
 
     public function provider_testComparisonOfIllegalUsage()
     {
@@ -341,7 +340,6 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     {
         $r = $a->compare($b);
     }
-
 
     public function provider_testCompareToZero()
     {
@@ -377,7 +375,7 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testCompareToZero(Money $a, $result)
     {
         $r = $a->compareToZero();
-        $this->assertTrue($r == $result, "comparing to zero: " . $a->asString() . ", result: " . $r . ", expected: " . $result);
+        $this->assertEquals($result, $r, "comparing to zero: " . $a->asString() . ", result: " . $r . ", expected: " . $result);
     }
 
     public function provider_testIsZero()
@@ -414,7 +412,7 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testIsZero(Money $a, $result)
     {
         $r = $a->isZero();
-        $this->assertTrue($r == $result, "comparing to zero: " . $a->asString() . ", result: " . $r . ", expected: " . $result);
+        $this->assertEquals($result, $r, "comparing to zero: " . $a->asString() . ", result: " . $r . ", expected: " . $result);
     }
 
     public function provider_testIsEqual()
@@ -448,7 +446,7 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testIsEqual(Money $a, Money $b, $result)
     {
         $r = $a->isEqual($b);
-        $this->assertTrue($r == $result, "isEqual: " . $a->asString() . ' == ' . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: " . ($result ? 'true' : 'false'));
+        $this->assertEquals($result, $r, "isEqual: " . $a->asString() . ' == ' . $b->asString() . ", result: " . ($r ? 'true' : 'false') . ", expected: " . ($result ? 'true' : 'false'));
     }
 
     public function provider_testIsEqualExact()
@@ -481,18 +479,17 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testIsEqualExact(Money $a, Money $b, $result)
     {
         $r = $a->isEqualExact($b);
-        $this->assertTrue($r == $result, "isEqualExact: " . $a->asString() . ' === ' . $b->asString() . ", result: " . $r . ", expected: " . $result);
+        $this->assertEquals($result, $r, "isEqualExact: " . $a->asString() . ' === ' . $b->asString() . ", result: " . $r . ", expected: " . $result);
     }
 
     public function testGetters()
     {
         $a = Money::create('5.43210', 'LTL', 5);
-        $this->assertTrue($a->getAmount() === '5.43210', "getter test failed: incorrect getAmount();");
-        $this->assertTrue($a->getCurrency() === 'LTL', "getter test failed: incorrect getCurrency();");
-        $this->assertTrue($a->getPrecision() === 5, "getter test failed: incorrect getPrecision();");
-        $this->assertTrue($a->asString() === '5.43210 LTL', "getter test failed: incorrect asString(); returned: " . $a->asString() . ", should: 5.43210 LTL");
+        $this->assertSame('5.43210', $a->getAmount(), "getter test failed: incorrect getAmount();");
+        $this->assertSame('LTL', $a->getCurrency(), "getter test failed: incorrect getCurrency();");
+        $this->assertSame(5, $a->getPrecision(), "getter test failed: incorrect getPrecision();");
+        $this->assertSame('5.43210 LTL', $a->asString(), "getter test failed: incorrect asString(); returned: " . $a->asString() . ", should: 5.43210 LTL");
     }
-
 
     public function provider_testNegate()
     {
@@ -542,9 +539,10 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testUndefined($currency, $precision)
     {
         $money = Money::undefined($currency, $precision);
+        $precision = $precision >= 0 ? $precision : 4;
 
         $this->assertEquals($currency, $money->getCurrency(), "currency not match");
-        $this->assertEquals($precision >= 0 ? $precision : 4, $money->getPrecision(), "precision not match");
+        $this->assertEquals($precision, $money->getPrecision(), "precision not match");
     }
 
     public function testSetDefaultCurrency()
@@ -560,17 +558,18 @@ class MoneyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($defautCurrency, $money->getCurrency(), "money() created not correct currency value = ".$money->asString());
     }
 
-
     public function assertMoney(Money $money, $amount, $currency, $precision = 0)
     {
-        $this->assertTrue($money->getAmount() == $amount, "amount mismatch. must be {$amount}, got: " . $money->getAmount());
-        $this->assertTrue($money->getCurrency() == $currency, "currency mismatch. must be {$currency}, got: " . $money->getCurrency());
+        $this->assertEquals($amount, $money->getAmount(), "amount mismatch. must be {$amount}, got: " . $money->getAmount());
+        $this->assertEquals($currency, $money->getCurrency(), "currency mismatch. must be {$currency}, got: " . $money->getCurrency());
 
-        if ($precision)
-            $this->assertTrue($money->getPrecision() == $precision, "precision mismatch. must be {$precision}, got: " . $money->getPrecision());
+        if ($precision) {
+            $this->assertEquals($precision, $money->getPrecision(), "precision mismatch. must be {$precision}, got: " . $money->getPrecision());
+        }
     }
 
-    public function provider_testMultiplyByInteger() {
+    public function provider_testMultiplyByInteger()
+    {
         return array(
             array(Money::create('0.00', ''), 5, Money::create('0.00', '')),
             array(Money::create('15.63', 'LTL'), 5, Money::create('78.15', 'LTL')),
@@ -582,7 +581,8 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider provider_testMultiplyByInteger
      */
-    public function testMultiplyByInteger(Money $money, $number, Money $expectedResult) {
+    public function testMultiplyByInteger(Money $money, $number, Money $expectedResult)
+    {
         $result = $money->multiplyByInteger($number);
         $this->assertTrue($result->isEqual($expectedResult), 'Test money * number failed. (' . $money->asString() . ') * (' . $result->asString() . '), expected: ' . $expectedResult->asString());
     }

--- a/tests/MutablemoneyTest.php
+++ b/tests/MutablemoneyTest.php
@@ -1,10 +1,14 @@
 <?php
-require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.'MockedMoneyConverter.php');
 
-class MutableMoneyTest extends PHPUnit_Framework_TestCase
+namespace HappyTypes\Test\MoneyType;
+
+use HappyTypes\Money;
+use HappyTypes\MutableMoney;
+use PHPUnit\Framework\TestCase;
+
+class MutableMoneyTest extends TestCase
 {
-
-    public function setUp()
+    protected function setUp()
     {
         Money::setDefaultMoneyConverter(new MockedMoneyConverter());
         Money::setDefaultCurrency(null);
@@ -13,7 +17,6 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
     public function provider_testAdd()
     {
         return array(
-
 
             array(MutableMoney::create('0.00', 'LTL'), Money::create('0.00', 'LTL'), Money::create('0.00', 'LTL')),
 
@@ -73,7 +76,6 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($result->isEqual($expectedResult), 'Test A - B failed. ' . $a->asString() . ' - ' . $b->asString() . ' = ' . $result->asString() . ', expected: ' . $expectedResult->asString());
     }
 
-
     public function testConvertTo()
     {
         $a        = MutableMoney::create('2.00', 'EUR');
@@ -112,7 +114,6 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($b->isEqualExact($result), "negate() incorrectly, " . $original->asString() . ".negate() result: " . $b->asString() . ", should be: " . $result->asString());
     }
 
-
     public function testImmutable()
     {
         $a = MutableMoney::create('20.00', 'LTL');
@@ -123,7 +124,7 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
 
         $adding = Money::create('1.00', 'LTL');
 
-        $value = $immutable->add($adding);
+        $immutable->add($adding);
 
         $this->assertTrue($immutable->isEqualExact($a), "immutable(): adding to immutable value must not change its state. (immutable)" . $immutable->asString() . " + " . $adding->asString() . " => " . $immutable->asString());
     }
@@ -159,7 +160,7 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
     {
         $original = MutableMoney::from($a);
         $r        = $a->isEqualExact($b);
-        $this->assertTrue($r == $result, "isEqualExact: " . $a->asString() . ' === ' . $b->asString() . ", result: " . $r . ", expected: " . $result);
+        $this->assertEquals($r, $result, "isEqualExact: " . $a->asString() . ' === ' . $b->asString() . ", result: " . $r . ", expected: " . $result);
         $this->assertTrue($original->isEqualExact($a), "isEqualExact: failed. mutable money object value was changed due function call! isEqualExact cannot change values itself.");
     }
 
@@ -174,7 +175,6 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
         $expected = Money::create('123.45', 'LTL', 2);
         $this->assertTrue($expected->isEqualExact($a), $input->asString() . " applied toPrecision(2) and got result ".$a->asString().", expected: ".$expected->asString());
     }
-
 
     public function provider_testUndefinedBugWhenCreatingMultipleValuesWithDifferentCurrencies()
     {
@@ -195,24 +195,22 @@ class MutableMoneyTest extends PHPUnit_Framework_TestCase
     public function testUndefined($currency, $precision)
     {
         $money = Money::undefined($currency, $precision);
+        $precision = $precision >= 0 ? $precision : 4;
 
         $this->assertEquals($currency, $money->getCurrency(), "currency not match");
-        $this->assertEquals($precision >= 0 ? $precision : 4, $money->getPrecision(), "precision not match");
+        $this->assertEquals($precision, $money->getPrecision(), "precision not match");
     }
-
 
     public function testSetDefaultCurrency()
     {
-        $defautCurrency = 'EUR';
+        $defaultCurrency = 'EUR';
 
-        Money::setDefaultCurrency($defautCurrency);
+        Money::setDefaultCurrency($defaultCurrency);
 
         $undefined = Money::undefined();
         $money = Money::create('10.0000');
 
-        $this->assertEquals($defautCurrency, $undefined->getCurrency(), "undefined() created not correct currency value");
-        $this->assertEquals($defautCurrency, $money->getCurrency(), "money() created not correct currency value = ".$money->asString());
+        $this->assertEquals($defaultCurrency, $undefined->getCurrency(), "undefined() created not correct currency value");
+        $this->assertEquals($defaultCurrency, $money->getCurrency(), "money() created not correct currency value = ".$money->asString());
     }
-
-
 }


### PR DESCRIPTION
# Changed log
- Resolves issue #5.
- Initialize automatic unit tests work with Travis CI.
- Add the `HappyTypes` namespace for `MoneyType` class.
- Improvements for assertion approach on Test classes.
- The Travis CI build log on forked repository is available [here](https://travis-ci.org/open-source-contributions/php-money-type/builds/627172636).